### PR TITLE
remove old kernel 3.x support. Using kernel 4.4.x for travis-ci build test. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ compiler:
 
 env:
   - KERNEL_VERSION=3.13.0-29-generic
-  - KERNEL_VESION=4.4.0-21-generic
-  - KERNEL_VERSION=4.10.0-33-generic
+  - KERNEL_VERSION=4.4.0-78-generic
 
 notifications:
     mail: "mbehr@mcbehr.de"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler:
 
 env:
   - KERNEL_VERSION=3.13.0-29-generic
+  - KERNEL_VESION=4.4.0-21-generic
   - KERNEL_VERSION=4.10.0-33-generic
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ compiler:
     - gcc
 
 env:
-  - KERNEL_VERSION=3.13.0-29-generic
   - KERNEL_VERSION=4.4.0-78-generic
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ compiler:
     - gcc
 
 env:
-  - KERNEL_VERSION=3.2.0-64-generic
-  - KERNEL_VERSION=3.5.0-51-generic
-  - KERNEL_VERSION=3.8.0-42-generic
-  - KERNEL_VERSION=3.11.0-23-generic
   - KERNEL_VERSION=3.13.0-29-generic
+  - KERNEL_VERSION=4.10.0-33-generic
 
 notifications:
     mail: "mbehr@mcbehr.de"


### PR DESCRIPTION
Removed own ewma function.
Changed travis to use kernel 4.4.0-78.